### PR TITLE
ci: Add simple docker CI for pushing to ghcr on main branch

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -14,17 +14,27 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Login to GitHub Container Registry
-        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and Push API Docker Image
-        working-directory: api
-        run: |
-          docker build -t ghcr.io/${{ github.repository_owner }}/alldeals-ng/api:latest .
-          docker push ghcr.io/${{ github.repository_owner }}/alldeals-ng/api:latest
+        uses: docker/build-push-action@v5
+        with:
+          context: ./api/
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/alldeals-ng/api:latest 
 
       - name: Build and Push Frontend Docker Image
-        working-directory: solid
-        run: |
-          docker build -t ghcr.io/${{ github.repository_owner }}/alldeals-ng/frontend:latest .
-          docker push ghcr.io/${{ github.repository_owner }}/alldeals-ng/frontend:latest
-
+        uses: docker/build-push-action@v5
+        with:
+          context: ./solid/
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/alldeals-ng/frontend:latest 

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,0 +1,30 @@
+name: Docker Publish
+
+on:
+  push:
+    branches:
+      - main 
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Login to GitHub Container Registry
+        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+
+      - name: Build and Push API Docker Image
+        working-directory: api
+        run: |
+          docker build -t ghcr.io/${{ github.repository_owner }}/alldeals-ng/api:latest .
+          docker push ghcr.io/${{ github.repository_owner }}/alldeals-ng/api:latest
+
+      - name: Build and Push Frontend Docker Image
+        working-directory: solid
+        run: |
+          docker build -t ghcr.io/${{ github.repository_owner }}/alldeals-ng/frontend:latest .
+          docker push ghcr.io/${{ github.repository_owner }}/alldeals-ng/frontend:latest
+

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
This adds a simple CI for docker.

Please create a `GHCR_PAT` secret in the repository and add it as a CI variable for being able to push to GHCR.
-> Token needs to be able to access the GitHub Container Registry.